### PR TITLE
Level wide preview

### DIFF
--- a/CrashEdit/Controllers/NSFController.cs
+++ b/CrashEdit/Controllers/NSFController.cs
@@ -1,6 +1,7 @@
 using Crash;
 using System;
 using System.Collections.Generic;
+using System.Windows.Forms;
 
 namespace CrashEdit
 {
@@ -10,54 +11,56 @@ namespace CrashEdit
         private GameVersion gameversion;
         public short chunkid;
 
-        public NSFController(NSF nsf,GameVersion gameversion)
+        public NSFController(NSF nsf, GameVersion gameversion)
         {
             this.nsf = nsf;
             this.gameversion = gameversion;
             chunkid = -1;
             foreach (Chunk chunk in nsf.Chunks)
             {
-                chunkid += 2; 
+                chunkid += 2;
                 if (chunk is NormalChunk)
                 {
-                    AddNode(new NormalChunkController(this,(NormalChunk)chunk));
+                    AddNode(new NormalChunkController(this, (NormalChunk)chunk));
                 }
                 else if (chunk is TextureChunk)
                 {
-                    AddNode(new TextureChunkController(this,(TextureChunk)chunk));
+                    AddNode(new TextureChunkController(this, (TextureChunk)chunk));
                 }
                 else if (chunk is OldSoundChunk)
                 {
-                    AddNode(new OldSoundChunkController(this,(OldSoundChunk)chunk));
+                    AddNode(new OldSoundChunkController(this, (OldSoundChunk)chunk));
                 }
                 else if (chunk is SoundChunk)
                 {
-                    AddNode(new SoundChunkController(this,(SoundChunk)chunk));
+                    AddNode(new SoundChunkController(this, (SoundChunk)chunk));
                 }
                 else if (chunk is WavebankChunk)
                 {
-                    AddNode(new WavebankChunkController(this,(WavebankChunk)chunk));
+                    AddNode(new WavebankChunkController(this, (WavebankChunk)chunk));
                 }
                 else if (chunk is SpeechChunk)
                 {
-                    AddNode(new SpeechChunkController(this,(SpeechChunk)chunk));
+                    AddNode(new SpeechChunkController(this, (SpeechChunk)chunk));
                 }
                 else if (chunk is UnprocessedChunk)
                 {
-                    AddNode(new UnprocessedChunkController(this,(UnprocessedChunk)chunk));
+                    AddNode(new UnprocessedChunkController(this, (UnprocessedChunk)chunk));
                 }
                 else
                 {
                     throw new NotImplementedException();
                 }
             }
-            AddMenu("Add Chunk - Normal",Menu_Add_NormalChunk);
-            AddMenu("Add Chunk - Sound",Menu_Add_SoundChunk);
-            AddMenu("Add Chunk - Wavebank",Menu_Add_WavebankChunk);
-            AddMenu("Add Chunk - Speech",Menu_Add_SpeechChunk);
+            AddMenu("Add Chunk - Normal", Menu_Add_NormalChunk);
+            AddMenu("Add Chunk - Sound", Menu_Add_SoundChunk);
+            AddMenu("Add Chunk - Wavebank", Menu_Add_WavebankChunk);
+            AddMenu("Add Chunk - Speech", Menu_Add_SpeechChunk);
             AddMenuSeparator();
-            AddMenu("Fix Nitro Detonators",Menu_Fix_Detonator);
-            AddMenu("Fix Box Count",Menu_Fix_BoxCount);
+            AddMenu("Fix Nitro Detonators", Menu_Fix_Detonator);
+            AddMenu("Fix Box Count", Menu_Fix_BoxCount);
+            AddMenuSeparator();
+            AddMenu("Show all level geometry", Menu_LoadFullScenery);
             InvalidateNode();
         }
 
@@ -82,7 +85,7 @@ namespace CrashEdit
         {
             NormalChunk chunk = new NormalChunk();
             nsf.Chunks.Add(chunk);
-            NormalChunkController controller = new NormalChunkController(this,chunk);
+            NormalChunkController controller = new NormalChunkController(this, chunk);
             AddNode(controller);
             chunkid += 2;
         }
@@ -91,7 +94,7 @@ namespace CrashEdit
         {
             SoundChunk chunk = new SoundChunk();
             nsf.Chunks.Add(chunk);
-            SoundChunkController controller = new SoundChunkController(this,chunk);
+            SoundChunkController controller = new SoundChunkController(this, chunk);
             AddNode(controller);
             chunkid += 2;
         }
@@ -100,7 +103,7 @@ namespace CrashEdit
         {
             WavebankChunk chunk = new WavebankChunk();
             nsf.Chunks.Add(chunk);
-            WavebankChunkController controller = new WavebankChunkController(this,chunk);
+            WavebankChunkController controller = new WavebankChunkController(this, chunk);
             AddNode(controller);
             chunkid += 2;
         }
@@ -109,7 +112,7 @@ namespace CrashEdit
         {
             SpeechChunk chunk = new SpeechChunk();
             nsf.Chunks.Add(chunk);
-            SpeechChunkController controller = new SpeechChunkController(this,chunk);
+            SpeechChunkController controller = new SpeechChunkController(this, chunk);
             AddNode(controller);
             chunkid += 2;
         }
@@ -244,8 +247,116 @@ namespace CrashEdit
             {
                 if (willy.BoxCount.HasValue)
                 {
-                    willy.BoxCount = new EntitySetting(0,boxcount);
+                    willy.BoxCount = new EntitySetting(0, boxcount);
                 }
+            }
+        }
+
+        private void Menu_LoadFullScenery()
+        {
+            if (gameversion == GameVersion.Crash1Beta1995 || gameversion == GameVersion.Crash1BetaMAR08 || gameversion == GameVersion.Crash1BetaMAY11)
+            {
+                List<ProtoSceneryEntry> entries = new List<ProtoSceneryEntry>();
+
+                foreach (Chunk chunk in nsf.Chunks)
+                {
+                    if (chunk is EntryChunk)
+                    {
+                        EntryChunk entryChunk = chunk as EntryChunk;
+
+                        foreach (Entry entry in entryChunk.Entries)
+                        {
+                            if (entry is ProtoSceneryEntry)
+                            {
+                                entries.Add(entry as ProtoSceneryEntry);
+                            }
+                        }
+                    }
+                }
+
+                Form form = new Form { Width = 800, Height = 600 };
+                ProtoSceneryEntryViewer viewer = new ProtoSceneryEntryViewer(entries) { Dock = DockStyle.Fill };
+                form.Controls.Add(viewer);
+                form.Show();
+            }
+            else if (gameversion == GameVersion.Crash1)
+            {
+                List<OldSceneryEntry> entries = new List<OldSceneryEntry>();
+
+                foreach (Chunk chunk in nsf.Chunks)
+                {
+                    if (chunk is EntryChunk)
+                    {
+                        EntryChunk entryChunk = chunk as EntryChunk;
+
+                        foreach (Entry entry in entryChunk.Entries)
+                        {
+                            if (entry is OldSceneryEntry)
+                            {
+                                entries.Add(entry as OldSceneryEntry);
+                            }
+                        }
+                    }
+                }
+
+                Form form = new Form { Width = 800, Height = 600 };
+                OldSceneryEntryViewer viewer = new OldSceneryEntryViewer(entries) { Dock = DockStyle.Fill };
+                form.Controls.Add(viewer);
+                form.Show();
+            }
+            else if(gameversion == GameVersion.Crash2)
+            {
+                List<SceneryEntry> entries = new List<SceneryEntry>();
+
+                foreach (Chunk chunk in nsf.Chunks)
+                {
+                    if (chunk is EntryChunk)
+                    {
+                        EntryChunk entryChunk = chunk as EntryChunk;
+
+                        foreach (Entry entry in entryChunk.Entries)
+                        {
+                            if (entry is SceneryEntry)
+                            {
+                                entries.Add(entry as SceneryEntry);
+                            }
+                        }
+                    }
+                }
+
+                Form form = new Form { Width = 800, Height = 600 };
+                SceneryEntryViewer viewer = new SceneryEntryViewer(entries) { Dock = DockStyle.Fill };
+                form.Controls.Add(viewer);
+                form.Show();
+            }
+            else if (gameversion == GameVersion.Crash3)
+            {
+                List<NewSceneryEntry> entries = new List<NewSceneryEntry>();
+
+                foreach (Chunk chunk in nsf.Chunks)
+                {
+                    if (chunk is EntryChunk)
+                    {
+                        EntryChunk entryChunk = chunk as EntryChunk;
+
+                        foreach (Entry entry in entryChunk.Entries)
+                        {
+                            if (entry is NewSceneryEntry)
+                            {
+                                entries.Add(entry as NewSceneryEntry);
+                            }
+                        }
+                    }
+                }
+
+                Form form = new Form { Width = 800, Height = 600 };
+                NewSceneryEntryViewer viewer = new NewSceneryEntryViewer(entries) { Dock = DockStyle.Fill };
+                form.Controls.Add(viewer);
+                form.Show();
+            }
+            else
+            {
+                MessageBox.Show("The specified game version is not supported", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
     }


### PR DESCRIPTION
- Support for displaying whole level geometry in a popup window (doesnt include zone data). Should work with all crash releases (only tested Crash 1, 2 and 3, dont have prototypes to test it)

Signed-off-by: Alexis Maiquez Murcia almamu@almamu.com
